### PR TITLE
Not "official" Firefox

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-Librefox : Official Firefox With Freedom [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Librefox%2C%20official%20firefox%20with%20a%20better%20privacy%2C%20security%20and%20performance&url=https://github.com/intika/Librefox-Firefox&via=intika&hashtags=firefox,librefox,browser,privacy,developers)
+Librefox : Firefox With Freedom [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Librefox%2C%20official%20firefox%20with%20a%20better%20privacy%2C%20security%20and%20performance&url=https://github.com/intika/Librefox-Firefox&via=intika&hashtags=firefox,librefox,browser,privacy,developers)
 ----------------------------------------
 
 This project aim to fix privacy and security issues related to firefox without losing performances nor forking the project. It uses `local-settings.js`, `mozilla.cfg` and `policies.json`.

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@
 
 ---
 
-Librefox : Firefox With Freedom [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Librefox%2C%20official%20firefox%20with%20a%20better%20privacy%2C%20security%20and%20performance&url=https://github.com/intika/Librefox-Firefox&via=intika&hashtags=firefox,librefox,browser,privacy,developers)
+Librefox : Modifications to Official Firefox With Freedom [![Tweet](https://img.shields.io/twitter/url/http/shields.io.svg?style=social)](https://twitter.com/intent/tweet?text=Librefox%2C%20official%20firefox%20with%20a%20better%20privacy%2C%20security%20and%20performance&url=https://github.com/intika/Librefox-Firefox&via=intika&hashtags=firefox,librefox,browser,privacy,developers)
 ----------------------------------------
 
 This project aim to fix privacy and security issues related to firefox without losing performances nor forking the project. It uses `local-settings.js`, `mozilla.cfg` and `policies.json`.


### PR DESCRIPTION
This is not an "official" version of Firefox, so remove the "official" from the headline. 